### PR TITLE
Lmps check exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ pysimm can integrate seamlessly with parts of the LAMMPS simulation software pac
 
 ```echo "export LAMMPS_EXEC=/usr/bin/lmp_mpi" >> ~/.bashrc```
 
-If the LAMMPS_EXEC environment variable is not set, you will see a warning when importing the lmps module. Once configured, try the examples in the repository which highlight some of the features of pysimm.
+Correct configuration can be checked by using the following code:
+
+```
+from pysimm import lmps
+lmps.check_lmps_exec()
+```
+
+If the LAMMPS_EXEC environment variable is not set, you will see a warning. Once configured, try the examples in the repository which highlight some of the features of pysimm.
 
 Complete Installation (pysimm and LAMMPS)
 =========================================

--- a/pysimm/lmps.py
+++ b/pysimm/lmps.py
@@ -70,7 +70,6 @@ def check_lmps_exec():
             print 'LAMMPS is not configured properly for one reason or another'
             return False
             
-check_lmps_exec()
 
 class Qeq(object):
     """pysimm.lmps.MolecularDynamics


### PR DESCRIPTION
Remove call to check_lmps_exec() when lmps module is imported. Addresses #9. Updates README as well to reflect change. Users can now check the interface configuration with LAMMPS at their leisure.